### PR TITLE
Update runXSecLooper.cpp

### DIFF
--- a/runXSecLooper.cpp
+++ b/runXSecLooper.cpp
@@ -9,6 +9,9 @@
 #include <cstdlib>
 typedef unsigned int uint;
 
+using namespace PlotUtils;
+using namespace std;
+
 class MinModDepCCQEXSec : public XSec
 {
 public:


### PR DESCRIPTION
Adding the namespace `PlotUtils` and `std`. The compilations fails with `ChainWrapper` and `string` otherwise in an offline version.